### PR TITLE
Naprawienie skryptu make (#34)

### DIFF
--- a/make
+++ b/make
@@ -4,5 +4,9 @@ E=$?
 echo GET $E
 if [ "$1" != "o" ]; then
   /usr/bin/time --quiet -f'\nTime %U. Exit %x. Memory %M.' ./a.out
+  if [ "$?" = "127" ]; then
+    ./a.out
+    echo "\nTime n/a. Exit $?. Memory n/a."
+  fi
 fi
 exit $E


### PR DESCRIPTION
Problem polegał na braku pliku `/usr/bin/time` na niektórych dystrybucjach Linuxa, który był potrzebny do liczenia czasu wykonywania oraz zajętej pamięci przez program. Dodałem, że w przypadku braku takiego pliku te obliczenia są pomijane.